### PR TITLE
Add per-record execution_time_ms to getPercil/getSuggestions and update frontend

### DIFF
--- a/public/action/getPercil.php
+++ b/public/action/getPercil.php
@@ -120,12 +120,15 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
     ';
 
     // Eksekusi query
+    $startTime = microtime(true);
     $result = pg_query($dbconn, $query);
+    $executionTimeMs = (microtime(true) - $startTime) * 1000;
 
     $resultDB = [];
 
     if (pg_num_rows($result) > 0) {
         while ($row = pg_fetch_assoc($result)) {
+            $row['execution_time_ms'] = $executionTimeMs;
             $resultDB[] = $row;
         }
     }

--- a/public/action/getSuggestions.php
+++ b/public/action/getSuggestions.php
@@ -36,11 +36,16 @@ if ($searchField && $searchValue) {
         LIMIT 10
     ";
 
+        $startTime = microtime(true);
         $result = pg_query($dbconn, $query);
+        $executionTimeMs = (microtime(true) - $startTime) * 1000;
         $suggestions = [];
 
         while ($row = pg_fetch_assoc($result)) {
-            $suggestions[] = $row['result'];
+            $suggestions[] = [
+                'result' => $row['result'],
+                'execution_time_ms' => $executionTimeMs,
+            ];
         }
 
         header('Content-Type: application/json');

--- a/public/js/map.js
+++ b/public/js/map.js
@@ -892,7 +892,7 @@ $("#searchValue").on("input", function () {
       let listItems = "";
       if (data.length > 0) {
         data.forEach((item) => {
-          const safeItem = $("<div>").text(item).html();
+          const safeItem = $("<div>").text(item.result).html();
           listItems += `<li class="px-3 py-1 cursor-pointer hover:bg-gray-100">${safeItem}</li>`;
         });
       } else {


### PR DESCRIPTION
### Motivation
- Expose per-query timing next to each returned record or suggestion without introducing a wrapper object so existing consumers still receive an array.
- Provide timing information in milliseconds for profiling while preserving the original response shape.

### Description
- Instrumented the DB queries with `microtime(true)` and compute `execution_time_ms` for each query.
- In `public/action/getPercil.php` add `execution_time_ms` as a field on each returned row and return the result array directly as JSON with `JSON_PRETTY_PRINT`.
- In `public/action/getSuggestions.php` return an array of objects with `result` and `execution_time_ms` fields (instead of plain strings) and update `public/js/map.js` to read `item.result` when rendering suggestions.
- Kept headers and existing connection closing logic intact.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69816f4c0c208330beadeb852d5e2576)