### PR TITLE
Measure total query+fetch time and attach `execution_time_ms` to returned rows

### DIFF
--- a/public/action/getPercil.php
+++ b/public/action/getPercil.php
@@ -122,18 +122,23 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
     // Eksekusi query
     $startTime = microtime(true);
     $result = pg_query($dbconn, $query);
-    $rows = [];
-    if (pg_num_rows($result) > 0) {
-        $rows = pg_fetch_all($result, PGSQL_ASSOC);
+    if ($result === false) {
+        error_log('getPercil.php query failed: ' . pg_last_error($dbconn));
+        http_response_code(500);
+        echo json_encode(['error' => 'Internal server error']);
+        pg_close($dbconn);
+        exit;
+    }
+    $rows = pg_fetch_all($result, PGSQL_ASSOC);
+    if ($rows === false) {
+        $rows = [];
     }
     $executionTimeMs = (microtime(true) - $startTime) * 1000;
 
-    $resultDB = [];
-
-    foreach ($rows as $row) {
+    $resultDB = array_map(function ($row) use ($executionTimeMs) {
         $row['execution_time_ms'] = $executionTimeMs;
-        $resultDB[] = $row;
-    }
+        return $row;
+    }, $rows);
 
     // Contoh output hasilnya
     header('Content-Type: application/json');

--- a/public/action/getPercil.php
+++ b/public/action/getPercil.php
@@ -120,14 +120,19 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
     ';
 
     // Eksekusi query
+    $startTime = microtime(true);
     $result = pg_query($dbconn, $query);
+    $rows = [];
+    if (pg_num_rows($result) > 0) {
+        $rows = pg_fetch_all($result, PGSQL_ASSOC);
+    }
+    $executionTimeMs = (microtime(true) - $startTime) * 1000;
 
     $resultDB = [];
 
-    if (pg_num_rows($result) > 0) {
-        while ($row = pg_fetch_assoc($result)) {
-            $resultDB[] = $row;
-        }
+    foreach ($rows as $row) {
+        $row['execution_time_ms'] = $executionTimeMs;
+        $resultDB[] = $row;
     }
 
     // Contoh output hasilnya

--- a/public/action/getSuggestions.php
+++ b/public/action/getSuggestions.php
@@ -38,9 +38,16 @@ if ($searchField && $searchValue) {
 
         $startTime = microtime(true);
         $result = pg_query($dbconn, $query);
-        $rows = [];
-        if (pg_num_rows($result) > 0) {
-            $rows = pg_fetch_all($result, PGSQL_ASSOC);
+        if ($result === false) {
+            error_log('getSuggestions.php query failed: ' . pg_last_error($dbconn));
+            http_response_code(500);
+            echo json_encode(['error' => 'Internal server error']);
+            pg_close($dbconn);
+            exit;
+        }
+        $rows = pg_fetch_all($result, PGSQL_ASSOC);
+        if ($rows === false) {
+            $rows = [];
         }
         $executionTimeMs = (microtime(true) - $startTime) * 1000;
         $suggestions = [];

--- a/public/action/getSuggestions.php
+++ b/public/action/getSuggestions.php
@@ -36,11 +36,20 @@ if ($searchField && $searchValue) {
         LIMIT 10
     ";
 
+        $startTime = microtime(true);
         $result = pg_query($dbconn, $query);
+        $rows = [];
+        if (pg_num_rows($result) > 0) {
+            $rows = pg_fetch_all($result, PGSQL_ASSOC);
+        }
+        $executionTimeMs = (microtime(true) - $startTime) * 1000;
         $suggestions = [];
 
-        while ($row = pg_fetch_assoc($result)) {
-            $suggestions[] = $row['result'];
+        foreach ($rows as $row) {
+            $suggestions[] = [
+                'result' => $row['result'],
+                'execution_time_ms' => $executionTimeMs,
+            ];
         }
 
         header('Content-Type: application/json');

--- a/public/action/getSuggestions.php
+++ b/public/action/getSuggestions.php
@@ -50,14 +50,12 @@ if ($searchField && $searchValue) {
             $rows = [];
         }
         $executionTimeMs = (microtime(true) - $startTime) * 1000;
-        $suggestions = [];
-
-        foreach ($rows as $row) {
-            $suggestions[] = [
+        $suggestions = array_map(function ($row) use ($executionTimeMs) {
+            return [
                 'result' => $row['result'],
                 'execution_time_ms' => $executionTimeMs,
             ];
-        }
+        }, $rows);
 
         header('Content-Type: application/json');
         echo json_encode($suggestions, JSON_PRETTY_PRINT);

--- a/public/js/map.js
+++ b/public/js/map.js
@@ -892,7 +892,7 @@ $("#searchValue").on("input", function () {
       let listItems = "";
       if (data.length > 0) {
         data.forEach((item) => {
-          const safeItem = $("<div>").text(item).html();
+          const safeItem = $("<div>").text(item.result).html();
           listItems += `<li class="px-3 py-1 cursor-pointer hover:bg-gray-100">${safeItem}</li>`;
         });
       } else {


### PR DESCRIPTION
### Motivation
- The previous timing only measured `pg_query` duration and omitted row-fetching time, which can underreport total latency for large results. 
- Make the `execution_time_ms` metric reflect the full duration from query start through fetching all rows while preserving the existing array response shape. 
- Update the suggestions UI to handle suggestion objects containing `result` instead of plain strings.

### Description
- In `public/action/getSuggestions.php` start the timer before `pg_query`, use `pg_fetch_all(..., PGSQL_ASSOC)` to load all rows, compute `execution_time_ms` after fetching, and return an array of objects each with `result` and `execution_time_ms`.
- In `public/action/getPercil.php` apply the same refactor: fetch all rows with `pg_fetch_all`, compute the timing after fetch, attach `execution_time_ms` to each record, and return the array as JSON.
- Update `public/js/map.js` to render suggestions using `item.result` instead of raw string items.
- Keep response headers and connection closing logic unchanged.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69816f4c0c208330beadeb852d5e2576)