### PR TITLE
Return execution_time_ms once per response and update consumers

### DIFF
--- a/public/action/getPercil.php
+++ b/public/action/getPercil.php
@@ -120,19 +120,29 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
     ';
 
     // Eksekusi query
+    $startTime = microtime(true);
     $result = pg_query($dbconn, $query);
-
-    $resultDB = [];
-
-    if (pg_num_rows($result) > 0) {
-        while ($row = pg_fetch_assoc($result)) {
-            $resultDB[] = $row;
-        }
+    if ($result === false) {
+        error_log('getPercil.php query failed: ' . pg_last_error($dbconn));
+        http_response_code(500);
+        echo json_encode(['error' => 'Internal server error']);
+        pg_close($dbconn);
+        exit;
     }
+    $rows = pg_fetch_all($result, PGSQL_ASSOC);
+    if ($rows === false) {
+        $rows = [];
+    }
+    $executionTimeMs = (microtime(true) - $startTime) * 1000;
+
+    $resultDB = $rows;
 
     // Contoh output hasilnya
     header('Content-Type: application/json');
-    echo json_encode($resultDB, JSON_PRETTY_PRINT);
+    echo json_encode([
+        'execution_time_ms' => $executionTimeMs,
+        'records' => $resultDB,
+    ], JSON_PRETTY_PRINT);
 
     // Tutup koneksi
     pg_close($dbconn);

--- a/public/action/getPercil.php
+++ b/public/action/getPercil.php
@@ -135,13 +135,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
     }
     $executionTimeMs = (microtime(true) - $startTime) * 1000;
 
-    $resultDB = $rows;
-
     // Contoh output hasilnya
     header('Content-Type: application/json');
     echo json_encode([
         'execution_time_ms' => $executionTimeMs,
-        'records' => $resultDB,
+        'records' => $rows,
     ], JSON_PRETTY_PRINT);
 
     // Tutup koneksi

--- a/public/action/getSuggestions.php
+++ b/public/action/getSuggestions.php
@@ -50,9 +50,7 @@ if ($searchField && $searchValue) {
             $rows = [];
         }
         $executionTimeMs = (microtime(true) - $startTime) * 1000;
-        $suggestions = array_map(function ($row) {
-            return $row['result'];
-        }, $rows);
+        $suggestions = array_column($rows, 'result');
 
         header('Content-Type: application/json');
         echo json_encode([

--- a/public/action/getSuggestions.php
+++ b/public/action/getSuggestions.php
@@ -36,15 +36,29 @@ if ($searchField && $searchValue) {
         LIMIT 10
     ";
 
+        $startTime = microtime(true);
         $result = pg_query($dbconn, $query);
-        $suggestions = [];
-
-        while ($row = pg_fetch_assoc($result)) {
-            $suggestions[] = $row['result'];
+        if ($result === false) {
+            error_log('getSuggestions.php query failed: ' . pg_last_error($dbconn));
+            http_response_code(500);
+            echo json_encode(['error' => 'Internal server error']);
+            pg_close($dbconn);
+            exit;
         }
+        $rows = pg_fetch_all($result, PGSQL_ASSOC);
+        if ($rows === false) {
+            $rows = [];
+        }
+        $executionTimeMs = (microtime(true) - $startTime) * 1000;
+        $suggestions = array_map(function ($row) {
+            return $row['result'];
+        }, $rows);
 
         header('Content-Type: application/json');
-        echo json_encode($suggestions, JSON_PRETTY_PRINT);
+        echo json_encode([
+            'execution_time_ms' => $executionTimeMs,
+            'suggestions' => $suggestions,
+        ], JSON_PRETTY_PRINT);
     }
 }
 

--- a/public/js/map.js
+++ b/public/js/map.js
@@ -715,9 +715,9 @@ const getPercil = async (agama = "", tipeHak = "", searchField = "", searchValue
       myAlert.show("error", "Gagal mengambil data", 1500);
       throw new Error(`HTTP error! status: ${response.status}`);
     }
-    const data = await response.json();
+    const payload = await response.json();
     myAlert.show("success", "Data persil berhasil dimuat", 1500);
-    return data;
+    return payload?.records || [];
   } catch (error) {
     console.error("Failed to fetch percil data:", error);
     return null;
@@ -740,6 +740,9 @@ async function loadPercilData(agama = "", tipeHak = "", searchField = "", search
   blokVisibility = {}; // reset blok toggle
 
   const data = await getPercil(agama, tipeHak, searchField, searchValue);
+  if (!data) {
+    return;
+  }
 
   data.forEach((item) => {
     try {
@@ -888,7 +891,7 @@ $("#searchValue").on("input", function () {
     method: "GET",
     data: { searchField, searchValue },
     success: function (response) {
-      const data = response;
+      const data = response?.suggestions || [];
       let listItems = "";
       if (data.length > 0) {
         data.forEach((item) => {


### PR DESCRIPTION
### Motivation
- Reduce payload size and redundancy by reporting `execution_time_ms` once per JSON response instead of attaching it to every row. 
- Ensure endpoints return a stable, machine-friendly envelope with both timing and data for easier client parsing. 
- Improve robustness by handling failing `pg_query` calls and normalizing `pg_fetch_all` results to an empty array. 

### Description
- Change `public/action/getPercil.php` to start the timer before query execution, check `if ($result === false)` and return a 500 JSON error on failure, use `pg_fetch_all(..., PGSQL_ASSOC)` normalized to `[]`, compute `execution_time_ms`, and return `{ execution_time_ms, records }` instead of per-row timings. 
- Change `public/action/getSuggestions.php` to start the timer before `pg_query`, handle query failures with a 500 JSON error, normalize `pg_fetch_all` to `[]`, compute `execution_time_ms`, and return `{ execution_time_ms, suggestions }` where `suggestions` is a simple array of values. 
- Update `public/js/map.js` to consume the new envelopes: `getPercil()` now reads `payload.records`, `loadPercilData()` guards against `null` payloads, and the suggestions AJAX handler reads `response.suggestions` and treats each suggestion as a primitive string. 
- Preserve existing response headers and ensure database connections are closed on error and success paths. 

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69816f4c0c208330beadeb852d5e2576)